### PR TITLE
Add new Host to allow external docker-compose.yml

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -8,6 +8,7 @@ Rails.application.configure do
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
   config.hosts << 'notifications-api.notifications.dev.convox'
+  config.hosts << 'notifications-api'
   config.hosts << '.sa.ngrok.io'
   config.hosts << '.ngrok.io'
 


### PR DESCRIPTION
These changes are required in order to include the notifications-api project in external docker-compose.yml files

